### PR TITLE
FIX Python 3 and 2 compatible exception raising for @threaded

### DIFF
--- a/etcd_settings/utils.py
+++ b/etcd_settings/utils.py
@@ -7,6 +7,7 @@ from collections import Mapping
 from functools import wraps
 from threading import Thread
 
+import six
 from dateutil.parser import parse as parse_date
 
 
@@ -53,10 +54,8 @@ class Task(Thread):
     def result(self):
         self.join()
         if self.__exc_info is not None:
-            # raise(self.__exc_info[0], self.__exc_info[1], self.__exc_info[2])
-            raise self.__exc_info[1].with_traceback(self.__exc_info[2])
-        else:
-            return self._result
+            six.reraise(*self.__exc_info)
+        return self._result
 
 
 def threaded(function=None, daemon=False):

--- a/requirements/requirements-base.txt
+++ b/requirements/requirements-base.txt
@@ -1,3 +1,4 @@
 Django>=1.7.5
 python-etcd>=0.4.1
 python-dateutil>=2.2
+six>=1.10.0,<2.0.0


### PR DESCRIPTION
Does not work in Python 2: `raise(self.__exc_info[0], self.__exc_info[1], self.__exc_info[2])`
Invalid syntax in Python 3: `raise self.__exc_info[1].with_traceback(self.__exc_info[2])`
Works in Python 2 and 3: `six.reraise(*self.__exc_info)`