### PR TITLE
OPT suppress false positive etcd.client errors with logging filter

### DIFF
--- a/etcd_settings/utils.py
+++ b/etcd_settings/utils.py
@@ -1,6 +1,7 @@
 import copy
 import datetime
 import json
+import logging
 import os
 import sys
 from collections import Mapping
@@ -131,3 +132,19 @@ def byteify(input):
         return input.encode('utf-8')
     else:
         return input
+
+
+class IgnoreMaxEtcdRetries(logging.Filter):
+    """
+    Skip etcd.client MaxRetryError on timeout
+    """
+
+    def __init__(self, name='etcd.client'):
+        super(IgnoreMaxEtcdRetries, self).__init__(name)
+
+    def filter(self, record):
+        msg = '{}'.format(record.args)
+        return not (
+            'MaxRetryError' in msg and
+            'Read timed out' in msg
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,40 @@
+import logging
+import unittest
+
+from etcd_settings import utils
+
+
+class TestLoggingFilter(unittest.TestCase):
+
+    def setUp(self):
+        self.logger_filter = utils.IgnoreMaxEtcdRetries()
+
+    def test_log_record_without_args(self):
+        self.assertTrue(
+            self.logger_filter.filter(
+                logging.LogRecord(
+                    'etcd.client',
+                    logging.ERROR,
+                    '/',
+                    0,
+                    'Read timed out',
+                    tuple(),
+                    None
+                )
+            )
+        )
+
+    def test_log_record_match(self):
+        self.assertFalse(
+            self.logger_filter.filter(
+                logging.LogRecord(
+                    'etcd.client',
+                    logging.ERROR,
+                    '/',
+                    0,
+                    'Error %s exception %s',
+                    ('Read timed out', 'MaxRetryError'),
+                    None
+                )
+            )
+        )


### PR DESCRIPTION
`etcd.client` logger in threads, which monitor changes of ETCD settings, send false positive `MaxRetryError` on timeout

This logging filter allows to suppress them if included into logging configuration