### PR TITLE
OPT add name to thread

### DIFF
--- a/etcd_settings/utils.py
+++ b/etcd_settings/utils.py
@@ -38,6 +38,7 @@ class Task(Thread):
     def __init__(self, method, *args, **kwargs):
         super(Task, self).__init__()
         self.method = method
+        self.name = 'DjangoETCDSettingsThread'
         self.args = args
         self.kwargs = kwargs
         self._result = None


### PR DESCRIPTION
Name the thread to make debugging multithreaded applications easier (Thread-3 vs DjangoETCDClientThread)